### PR TITLE
Update deprecated syntax for future rstan compatibility 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     methods,
     Rcpp (>= 0.12.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
+    rstan (>= 2.26.0),
     rstantools (>= 2.1.1),
     aniDom
 LinkingTo: 
@@ -31,8 +31,8 @@ LinkingTo:
     Rcpp (>= 0.12.0),
     RcppEigen (>= 0.3.3.3.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
-    StanHeaders (>= 2.18.0)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 SystemRequirements: GNU make
 Suggests: 
     rmarkdown,

--- a/inst/stan/ds_steep.stan
+++ b/inst/stan/ds_steep.stan
@@ -109,8 +109,8 @@ data {
   int<lower=0> N; // number of interactions
   int<lower=0> K; // number of dyads
   int I; // number of individuals
-  int interactions[N]; // interactions, 1/0
-  int dyad[N]; // actual dyad
+  array[N] int interactions; // interactions, 1/0
+  array[N] int dyad; // actual dyad
 }
 
 parameters{

--- a/inst/stan/multi_steep_fixed_sd.stan
+++ b/inst/stan/multi_steep_fixed_sd.stan
@@ -1,6 +1,6 @@
 functions {
-  real[] ProbFunction(vector EloStart, real k, matrix presence, int N, int K, int[] winner_index, int[] loser_index) {
-    real result[N];
+  array[] real ProbFunction(vector EloStart, real k, matrix presence, int N, int K, array[] int winner_index, array[] int loser_index) {
+    array[N] real result;
     real toAdd;
 
     vector[K] EloNow;
@@ -21,7 +21,7 @@ functions {
     return result;
   }
 
-  vector cum_winprob(vector EloStart, real k, int n_interactions, int n_ids, int[] winner_index, int[] loser_index) {
+  vector cum_winprob(vector EloStart, real k, int n_interactions, int n_ids, array[] int winner_index, array[] int loser_index) {
     real single_wp;
     real toAdd;
     matrix[n_ids, n_ids] pairwise_winprobs;
@@ -124,14 +124,14 @@ data {
   int<lower=1> N; // number of encounters
   int<lower=1> K; // number of individuals
   int<lower=1> n_rand; // number of randomized sequences
-  int<lower=1> winner[N, n_rand]; // winner's index
-  int<lower=1> loser[N, n_rand]; // losers's index
+  array[N, n_rand] int<lower=1> winner; // winner's index
+  array[N, n_rand] int<lower=1> loser; // losers's index
   matrix[N, K] presence;
-  int<lower=0> y[N]; // outcome, i.e. winner always wins -> all values are 1
+  array[N] int<lower=0> y; // outcome, i.e. winner always wins -> all values are 1
 }
 parameters {
   matrix[n_rand, K] EloStart_raw;
-  real<lower=0.0> k[n_rand];
+  array[n_rand] real<lower=0.0> k;
 }
 transformed parameters {
   matrix[n_rand, K] EloStart;

--- a/inst/stan/multi_steep_fixed_sd_fixed_k.stan
+++ b/inst/stan/multi_steep_fixed_sd_fixed_k.stan
@@ -1,6 +1,6 @@
 functions {
-  real[] ProbFunction(vector EloStart, real k, matrix presence, int N, int K, int[] winner_index, int[] loser_index) {
-    real result[N];
+  array[] real ProbFunction(vector EloStart, real k, matrix presence, int N, int K, array[] int winner_index, array[] int loser_index) {
+    array[N] real result;
     real toAdd;
 
     vector[K] EloNow;
@@ -21,7 +21,7 @@ functions {
     return result;
   }
 
-  vector cum_winprob(vector EloStart, real k, int n_interactions, int n_ids, int[] winner_index, int[] loser_index) {
+  vector cum_winprob(vector EloStart, real k, int n_interactions, int n_ids, array[] int winner_index, array[] int loser_index) {
     real single_wp;
     real toAdd;
     matrix[n_ids, n_ids] pairwise_winprobs;
@@ -124,15 +124,15 @@ data {
   int<lower=1> N; // number of encounters
   int<lower=1> K; // number of individuals
   int<lower=1> n_rand; // number of randomized sequences
-  int<lower=1> winner[N, n_rand]; // winner's index
-  int<lower=1> loser[N, n_rand]; // losers's index
+  array[N, n_rand] int<lower=1> winner; // winner's index
+  array[N, n_rand] int<lower=1> loser; // losers's index
   matrix[N, K] presence;
-  real<lower=0> k[n_rand];
-  int<lower=0> y[N]; // outcome, i.e. winner always wins -> all values are 1
+  array[n_rand] real<lower=0> k;
+  array[N] int<lower=0> y; // outcome, i.e. winner always wins -> all values are 1
 }
 parameters {
   matrix[n_rand, K] EloStart_raw;
-  // real<lower=0.0> k[n_rand];
+  // array[n_rand] real<lower=0.0> k;
 }
 transformed parameters {
   matrix[n_rand, K] EloStart;

--- a/inst/stan/multi_steep_original.stan
+++ b/inst/stan/multi_steep_original.stan
@@ -1,6 +1,6 @@
 functions {
-  real[] ProbFunction(real[] EloStart, real k, matrix presence, int N, int K, int[] Ai, int[] loser, real diff_f) {
-    real result[N];
+  array[] real ProbFunction(array[] real EloStart, real k, matrix presence, int N, int K, array[] int Ai, array[] int loser, real diff_f) {
+    array[N] real result;
     real toAdd;
     //real aux_mean = 0.0;
     vector[K] EloNow;
@@ -21,7 +21,7 @@ functions {
     return result;
   }
 
-  vector cum_winprob(vector EloStart, real k, int n_interactions, int n_ids, int[] Ai, int[] loser) {
+  vector cum_winprob(vector EloStart, real k, int n_interactions, int n_ids, array[] int Ai, array[] int loser) {
     real single_wp;
     real toAdd;
     matrix[n_ids, n_ids] pairwise_winprobs;
@@ -124,22 +124,22 @@ data {
   int<lower=1> N; // number of encounters
   int<lower=1> K; // number of individuals
   int<lower=1> n_rand; // number of randomized sequences
-  int<lower=1> winner[N, n_rand]; // winner's index
-  int<lower=1> loser[N, n_rand]; // losers's index
+  array[N, n_rand] int<lower=1> winner; // winner's index
+  array[N, n_rand] int<lower=1> loser; // losers's index
   matrix[N, K] presence;
-  int<lower=0> y[N]; // always 1
+  array[N] int<lower=0> y; // always 1
   real<lower=0> diff_f; // Elo Score difference factor
 }
 
 parameters {
-  real EloStart_raw[n_rand, K];
-  real<lower=0.0> k_raw[n_rand];
-  real<lower=0.0> sigma_raw[n_rand];
+  array[n_rand, K] real EloStart_raw;
+  array[n_rand] real<lower=0.0> k_raw;
+  array[n_rand] real<lower=0.0> sigma_raw;
 }
 
 transformed parameters {
-  real EloStart[n_rand, K];
-  real<lower=0.0> k[n_rand];
+  array[n_rand, K] real EloStart;
+  array[n_rand] real<lower=0.0> k;
   for (r in 1:n_rand) {
     for (i in 1:K) {
       EloStart[r, i] = EloStart_raw[r, i] - mean(EloStart_raw[r, ]);
@@ -163,7 +163,7 @@ model {
 }
 
 generated quantities{
-  real<lower=0.0> sigma[n_rand];
+  array[n_rand] real<lower=0.0> sigma;
   vector[n_rand] steepness;
   matrix[n_rand, K] cumwinprobs;
 


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
